### PR TITLE
Update DataCiteDoiHelper.cs

### DIFF
--- a/Modules/DIM/BExIS.Dim.Helper/DataCiteDOI/DataCiteDoiHelper.cs
+++ b/Modules/DIM/BExIS.Dim.Helper/DataCiteDOI/DataCiteDoiHelper.cs
@@ -50,8 +50,9 @@ namespace BExIS.Dim.Helpers
             doiMetadata.PrependChild(header);
 
             XmlElement resource = doiMetadata.CreateElement("resource");
+            resource.SetAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
             resource.SetAttribute("xmlns", "http://datacite.org/schema/kernel-4");
-            resource.SetAttribute("schemaLocation", "http://www.w3.org/2001/XMLSchema-instance", "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd");
+            resource.SetAttribute("xsi:schemaLocation", "http://www.w3.org/2001/XMLSchema-instance", "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd");
             doiMetadata.AppendChild(resource);
 
             XmlElement identifier = doiMetadata.CreateElement("identifier");


### PR DESCRIPTION
Potential fix for DOI (Module); tested manually on DataCite Fabrica;

This could be an easy solution for the non-working but existing DOI provider. At least some manual tests against the APIs from DataCite Fabrica claimed, that without the additional "xsi", the property name "schemaLocation" is invalid. If that isn't working and fixing the DOI provider module, I need to dig deeper.